### PR TITLE
datetime-picker: don't override theme colors

### DIFF
--- a/projects/datetime-picker/src/lib/datetime-content.component.scss
+++ b/projects/datetime-picker/src/lib/datetime-content.component.scss
@@ -2,8 +2,6 @@
   display: block;
   border-radius: 4px;
   box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
-  background-color: #fff;
-  color: rgba(0, 0, 0, 0.87);
   .mat-calendar {
     width: 296px;
   }


### PR DESCRIPTION
Currently the scss for the datetime picker overrides the background and text colors of the theme, leading to strange effects when using dark themes (using `@angular/material/prebuilt-themes/pink-bluegrey.css` here):
![pre](https://user-images.githubusercontent.com/24436551/78254425-2df48d80-74f6-11ea-955f-8486231c8a34.png)

After the fix:
![after](https://user-images.githubusercontent.com/24436551/78254457-3e0c6d00-74f6-11ea-9bbe-378312f88dc0.png)

