### PR TITLE
feat: make NgxMatCalendar and NgxMatCalendarHeader part of public-api

### DIFF
--- a/projects/datetime-picker/src/public-api.ts
+++ b/projects/datetime-picker/src/public-api.ts
@@ -2,6 +2,7 @@
  * Public API Surface of ngx-mat-datetime-picker
  */
 
+export * from './lib/calendar';
 export * from './lib/datetime-picker.component';
 export * from './lib/datetime-input';
 export * from './lib/datetime-picker.module';


### PR DESCRIPTION
This will fix https://github.com/h2qutc/angular-material-components/issues/47