### PR TITLE
Correct the AM/PM to 24h conversion (and vice versa)

### DIFF
--- a/projects/datetime-picker/src/lib/timepicker.component.ts
+++ b/projects/datetime-picker/src/lib/timepicker.component.ts
@@ -165,11 +165,14 @@ export class NgxMatTimepickerComponent<D> implements ControlValueAccessor, OnIni
     const _second = this._dateAdapter.getSecond(this._model);
 
     if (this.enableMeridian) {
-      if (_hour > LIMIT_TIMES.meridian) {
-        _hour = _hour - LIMIT_TIMES.meridian;
-        this.meridian = MERIDIANS.PM;
-      } else {
+      if (_hour < LIMIT_TIMES.meridian) {
         this.meridian = MERIDIANS.AM;
+      } else {
+        this.meridian = MERIDIANS.PM;
+        _hour = _hour - LIMIT_TIMES.meridian;
+      }
+      if (_hour === 0) {
+        _hour = LIMIT_TIMES.meridian;
       }
     }
 
@@ -181,8 +184,12 @@ export class NgxMatTimepickerComponent<D> implements ControlValueAccessor, OnIni
   /** Update model */
   private _updateModel() {
     let _hour = this.hour;
-    if (this.enableMeridian && this.meridian === MERIDIANS.PM && _hour !== LIMIT_TIMES.meridian) {
-      _hour = _hour + LIMIT_TIMES.meridian;
+    if (this.enableMeridian) {
+      if (this.meridian === MERIDIANS.AM && _hour === LIMIT_TIMES.meridian) {
+        _hour = 0;
+      } else if (this.meridian === MERIDIANS.PM && _hour !== LIMIT_TIMES.meridian) {
+        _hour = _hour + LIMIT_TIMES.meridian;
+      }
     }
 
     this._dateAdapter.setHour(this._model, _hour);
@@ -208,6 +215,9 @@ export class NgxMatTimepickerComponent<D> implements ControlValueAccessor, OnIni
     let next;
     if (up == null) {
       next = this[prop] % (max);
+      if (prop === 'hour' && this.enableMeridian) {
+        if (next === 0) next = max;
+      }
     } else {
       next = up ? this[prop] + this[`step${keyProp}`] : this[prop] - this[`step${keyProp}`];
       if (prop === 'hour' && this.enableMeridian) {


### PR DESCRIPTION
Fixes the hour conversion from and to AM/PM, see also #90 

hour 0-11 => AM and 0 should be shown as 12
hour 12-23 => PM where 12 remains 12 and the rest mod 12 (so 13=1, 14=2, etc)
hour 24-∞ => mod 12 and then rules above followed