### PR TITLE
change `_dateFilter()` type

### DIFF
--- a/projects/datetime-picker/src/lib/datetime-picker.component.ts
+++ b/projects/datetime-picker/src/lib/datetime-picker.component.ts
@@ -304,7 +304,7 @@ export class NgxMatDatetimePicker<D> implements OnDestroy, CanColor {
     return minValidators == null && maxValidators == null;
   }
 
-  get _dateFilter(): (date: D | null) => boolean {
+  get _dateFilter(): (date: D) => boolean {
     return this.datepickerInput && this.datepickerInput._dateFilter;
   }
 


### PR DESCRIPTION
It's only assigned to the property having `(date: D) => boolean` type.
So there's no need to declare it as `(date: D | null) => boolean`