### PR TITLE
Fix for issue 171: Midnight time is showing as 24:00 instead of 00:00

### DIFF
--- a/projects/datetime-picker/src/lib/core/native-date-formats.ts
+++ b/projects/datetime-picker/src/lib/core/native-date-formats.ts
@@ -10,7 +10,7 @@ import { NgxMatDateFormats } from './date-formats';
 
 const DEFAULT_DATE_INPUT = {
   year: 'numeric', month: 'numeric', day: 'numeric',
-  hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit"
+  hour: "2-digit", minute: "2-digit", second: "2-digit", hourCycle: 'h23'
 }
 
 export const NGX_MAT_NATIVE_DATE_FORMATS: NgxMatDateFormats = {


### PR DESCRIPTION
This issue is happening only in chromium based browsers and there is an open issue here https://support.google.com/chrome/thread/29828561/chrome-80-shows-timestamp-24-xx-instead-of-00-00?hl=en

For now, I have updated DEFAULT_DATE_INPUT based on this thread to fix this issue.