### PR TITLE
Allow selecting the last date user chose when they close the datetimepicker

### DIFF
--- a/projects/datetime-picker/src/lib/datetime-input.ts
+++ b/projects/datetime-picker/src/lib/datetime-input.ts
@@ -121,6 +121,9 @@ export class NgxMatDatetimeInput<D> implements ControlValueAccessor, OnDestroy, 
     }
     private _value: D | null;
 
+    @Input()
+    emitSelectedValueOnCancel = false;
+
     /** The minimum valid date. */
     @Input()
     get min(): D | null { return this._min; }
@@ -344,7 +347,7 @@ export class NgxMatDatetimeInput<D> implements ControlValueAccessor, OnDestroy, 
     _onFocus() {
         // Close datetime picker if opened
         if (this._datepicker && this._datepicker.opened) {
-            this._datepicker.cancel();
+            this._datepicker.cancel(this.emitSelectedValueOnCancel);
         }
     }
 

--- a/projects/datetime-picker/src/lib/datetime-picker.component.ts
+++ b/projects/datetime-picker/src/lib/datetime-picker.component.ts
@@ -377,9 +377,13 @@ export class NgxMatDatetimePicker<D> implements OnDestroy, CanColor {
   }
 
   /** Cancel and close */
-  public cancel(): void {
-    this._selected = this._rawValue;
-    this.close();
+  public cancel(emitSelectedValueOnCancel: boolean): void {
+    if (emitSelectedValueOnCancel) {
+      this.ok();
+    } else {
+      this._selected = this._rawValue;
+      this.close();
+    }
   }
 
   /**


### PR DESCRIPTION
When the user selects a date and closes the datetimepicker window
without clicking on the "Ok" (check-mark) button, it should be possible
to set the input value to the date that the user selected before closing
the window.

Unfortunately I was unable to test my code on this repository because the `npm ci` and `npm run start` commands fail, so please let me know how to test the code. 

Signed-off-by: Dinika Saxena <dinikasaxenas@gmail.com>