### PR TITLE
Color picker - Allow automatic format 1/2

### DIFF
--- a/projects/color-picker/src/lib/models/color-input-format.ts
+++ b/projects/color-picker/src/lib/models/color-input-format.ts
@@ -1,1 +1,1 @@
-export type ColorInputFormat = 'rgb' | 'hex' | 'hex6' | 'hex3' | 'hex4' | 'hex8';
+export type ColorInputFormat = 'rgb' | 'hex' | 'hex6' | 'hex3' | 'hex4' | 'hex8' | undefined;


### PR DESCRIPTION
'hex' by default
If there is an alpha 0≤a<1 shown rgba instead