### PR TITLE
Color picker - Allow automatic format 2/2

### DIFF
--- a/projects/color-picker/src/lib/models/color.model.ts
+++ b/projects/color-picker/src/lib/models/color.model.ts
@@ -53,14 +53,10 @@ export class Color {
     }
 
     public toString(format: ColorInputFormat): string {
-        let formatSet = !!format;
-
         let formattedString;
         let hasAlpha = this.a < 1 && this.a >= 0;
-        let needsAlphaFormat = !formatSet && hasAlpha && (format === "hex" || format === "hex6"
-            || format === "hex3" || format === "hex4" || format === "hex8");
 
-        if (needsAlphaFormat) {
+        if (hasAlpha) {
             return this.toRgbString();
         }
         if (format === "rgb") {


### PR DESCRIPTION
'hex' by default
If there is an alpha 0≤a<1 shown rgba instead