### PR TITLE
Set current time on Date selection - #356

### DIFF
--- a/projects/datetime-picker/src/lib/core/native-date-adapter.ts
+++ b/projects/datetime-picker/src/lib/core/native-date-adapter.ts
@@ -297,7 +297,8 @@ export class NgxMatNativeDateAdapter extends NgxMatDateAdapter<Date> {
 
   /** Creates a date but allows the month and date to overflow. */
   private _createDateWithOverflow(year: number, month: number, date: number) {
-    const result = new Date(year, month, date);
+    const now = new Date();
+    const result = new Date(year, month, date, now.getHours(), now.getMinutes(), now.getSeconds());
 
     // We need to correct for the fact that JS native Date treats years in range [0, 99] as
     // abbreviations for 19xx.


### PR DESCRIPTION
When user select a date from calendar the `NgxMatNativeDateAdapter` create a date with time equals to 00:00:00 (not really convinient). For most of scenarios current time it's the best default value instead of 00:00:00.
So i've forced time to `now` into `_createDateWithOverflow` method, adding hours, minutes and seconds into the date constructor. 
Furthermore that was the default behavior up to version 14.

Could solve issue #356 

