### PR TITLE
Fix update of min/max attributes when only the hours/minutes/seconds have changed

### DIFF
--- a/projects/datetime-picker/src/lib/core/date-adapter.ts
+++ b/projects/datetime-picker/src/lib/core/date-adapter.ts
@@ -57,8 +57,8 @@ export abstract class NgxMatDateAdapter<D> extends DateAdapter<D> {
 
   /**
    * Copy time from a date to a another date
-   * @param toDate 
-   * @param fromDate 
+   * @param toDate
+   * @param fromDate
    */
   copyTime(toDate: D, fromDate: D) {
     this.setHour(toDate, this.getHour(fromDate));
@@ -81,6 +81,16 @@ export abstract class NgxMatDateAdapter<D> extends DateAdapter<D> {
       res = res || this.getSecond(first) - this.getSecond(second);
     }
     return res;
+  }
+
+  /**
+ * Compares two dates and returns whether they are the same or not.
+ * @param first The first date to compare.
+ * @param second The second date to compare.
+ * @returns true if the dates are equal, false if they are not equal
+ */
+  sameDateWithTime(first: D, second: D): boolean {
+    return this.compareDateWithTime(first, second, true) === 0;
   }
 
   /**

--- a/projects/datetime-picker/src/lib/date-range-input.ts
+++ b/projects/datetime-picker/src/lib/date-range-input.ts
@@ -165,7 +165,7 @@ export class NgxMatDateRangeInput<D>
   set min(value: D | null) {
     const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
 
-    if (!this._dateAdapter.sameDate(validValue, this._min)) {
+    if (!this._dateAdapter.sameDateWithTime(validValue, this._min)) {
       this._min = validValue;
       this._revalidate();
     }
@@ -180,7 +180,7 @@ export class NgxMatDateRangeInput<D>
   set max(value: D | null) {
     const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
 
-    if (!this._dateAdapter.sameDate(validValue, this._max)) {
+    if (!this._dateAdapter.sameDateWithTime(validValue, this._max)) {
       this._max = validValue;
       this._revalidate();
     }

--- a/projects/datetime-picker/src/lib/datepicker-input.ts
+++ b/projects/datetime-picker/src/lib/datepicker-input.ts
@@ -75,7 +75,7 @@ export class NgxMatDatepickerInput<D>
   set min(value: D | null) {
     const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
 
-    if (!this._dateAdapter.sameDate(validValue, this._min)) {
+    if (!this._dateAdapter.sameDateWithTime(validValue, this._min)) {
       this._min = validValue;
       this._validatorOnChange();
     }
@@ -90,7 +90,7 @@ export class NgxMatDatepickerInput<D>
   set max(value: D | null) {
     const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
 
-    if (!this._dateAdapter.sameDate(validValue, this._max)) {
+    if (!this._dateAdapter.sameDateWithTime(validValue, this._max)) {
       this._max = validValue;
       this._validatorOnChange();
     }


### PR DESCRIPTION
The update of min/max values does not consider the change of hours, minutes or seconds. This is wrong, because even when min or max is updated but the date is the same only the time changes, these attributes are ignored and the validation is wrong.